### PR TITLE
either use the page title alone of the site title but not both

### DIFF
--- a/views/head.pug
+++ b/views/head.pug
@@ -1,6 +1,5 @@
 head
-  - let titleText = title
-  - if(pageTitle) titleText += ' - ' + pageTitle
+  - let titleText = (pageTitle) ? pageTitle : title
   title= titleText
   meta(name="viewport" content="width=device-width,initial-scale=1")
   - if(description)


### PR DESCRIPTION
Shortening title tags for better default SEO